### PR TITLE
chore: add JS to support instant experimentation

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -351,7 +351,7 @@ export async function getExperimentConfig(experimentId) {
     });
 
     return (config);
-  } 
+  }
   return null;
 }
 
@@ -412,7 +412,6 @@ async function decorateTesting() {
     console.log('error testing', e);
   }
 }
-
 
 /**
  * Gets placeholders object
@@ -819,10 +818,11 @@ async function loadPage(doc) {
   loadDelayed(doc);
 
   if (
-      window.location.hostname.endsWith('hlx.page') ||
-      window.location.hostname === 'localhost'
+    window.location.hostname.endsWith('hlx.page')
+    || window.location.hostname === 'localhost'
   ) {
-      import('../../tools/preview/preview.js');
+    // eslint-disable-next-line import/no-unresolved
+    import('../../tools/preview/preview.js');
   }
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -200,6 +200,220 @@ export function decorateYouTube(element = document) {
   });
 }
 
+export function checkTesting() {
+  const metaTesting = getMetadata('testing') || '';
+  return metaTesting.toLowerCase() === 'on';
+}
+
+/**
+ * gets the variant id that this visitor has been assigned to if any
+ * @param {string} experimentId
+ * @return {string} assigned variant or empty string if none set
+ */
+
+function getLastExperimentVariant(experimentId) {
+  console.log('get last experiment', experimentId);
+  const experimentsStr = localStorage.getItem('hlx-experiments');
+  if (experimentsStr) {
+    const experiments = JSON.parse(experimentsStr);
+    if (experiments[experimentId]) {
+      return experiments[experimentId].variant;
+    }
+  }
+  return '';
+}
+
+/**
+ * this is an extensible stub to take on audience mappings
+ * @param {string} audience
+ * @return {boolean} is member of this audience
+ */
+
+function checkExperimentAudience(audience) {
+  if (audience === 'mobile') {
+    return window.innerWidth < 600;
+  }
+  if (audience === 'desktop') {
+    return window.innerWidth > 600;
+  }
+  return true;
+}
+
+/**
+ * sets/updates the variant id that is assigned to this visitor,
+ * also cleans up old variant ids
+ * @param {string} experimentId
+ * @param {variant} variant
+ */
+
+function setLastExperimentVariant(experimentId, variant) {
+  const experimentsStr = localStorage.getItem('hlx-experiments');
+  const experiments = experimentsStr ? JSON.parse(experimentsStr) : {};
+
+  const now = new Date();
+  const expKeys = Object.keys(experiments);
+  expKeys.forEach((key) => {
+    const date = new Date(experiments[key].date);
+    if (now - date > (1000 * 86400 * 30)) {
+      delete experiments[key];
+    }
+  });
+  const [date] = now.toISOString().split('T');
+
+  experiments[experimentId] = { variant, date };
+  localStorage.setItem('hlx-experiments', JSON.stringify(experiments));
+}
+
+/**
+ * Replaces element with content from path
+ * @param {string} path
+ * @param {HTMLElement} element
+ */
+async function replaceInner(path, element) {
+  const plainPath = `${path}.plain.html`;
+  try {
+    const resp = await fetch(plainPath);
+    const html = await resp.text();
+    element.innerHTML = html;
+  } catch (e) {
+    console.log(`error loading experiment content: ${plainPath}`, e);
+  }
+  return null;
+}
+
+/**
+ * Gets the experiment name, if any for the page based on env, useragent, query params
+ * @returns {string} experimentid
+ */
+export function getExperiment() {
+  let experiment = toClassName(getMetadata('experiment'));
+
+  if (!window.location.host.includes('adobe.com') && !window.location.host.includes('.hlx.live')) {
+    experiment = '';
+    // reason = 'not prod host';
+  }
+  if (window.location.hash) {
+    experiment = '';
+    // reason = 'suppressed by #';
+  }
+
+  if (navigator.userAgent.match(/bot|crawl|spider/i)) {
+    experiment = '';
+    // reason = 'bot detected';
+  }
+
+  const usp = new URLSearchParams(window.location.search);
+  if (usp.has('experiment')) {
+    [experiment] = usp.get('experiment').split('/');
+  }
+
+  return experiment;
+}
+
+/**
+ * Gets experiment config for the instant experiment metadata and
+ * transforms it to more easily consumable structure.
+ *
+ * @param {string} experimentId
+ * @returns {object} containing the experiment metadata
+ */
+export async function getExperimentConfig(experimentId) {
+  const instantExperiment = getMetadata('instant-experiment');
+  if (instantExperiment) {
+    const config = {
+      experimentName: `Instant Experiment: ${experimentId}`,
+      audience: '',
+      status: 'Active',
+      id: experimentId,
+      variants: {},
+      variantNames: [],
+    };
+
+    const pages = instantExperiment.split(',').map((p) => new URL(p.trim()).pathname);
+    const evenSplit = 1 / (pages.length + 1);
+
+    config.variantNames.push('control');
+    config.variants.control = {
+      percentageSplit: '',
+      pages: [window.location.pathname],
+      blocks: [],
+      label: 'Control',
+    };
+
+    pages.forEach((page, i) => {
+      const vname = `challenger-${i + 1}`;
+      config.variantNames.push(vname);
+      config.variants[vname] = {
+        percentageSplit: `${evenSplit}`,
+        pages: [page],
+        label: `Challenger ${i + 1}`,
+      };
+    });
+
+    return (config);
+  } 
+  return null;
+}
+
+/**
+ * checks if a test is active on this page and if so executes the test
+ */
+async function decorateTesting() {
+  try {
+    const usp = new URLSearchParams(window.location.search);
+
+    const experiment = getExperiment();
+    const [forcedExperiment, forcedVariant] = usp.get('experiment') ? usp.get('experiment').split('/') : [];
+
+    if (experiment) {
+      console.log('experiment', experiment);
+      const config = await getExperimentConfig(experiment);
+      console.log(config);
+      if (toCamelCase(config.status) === 'active' || forcedExperiment) {
+        config.run = forcedExperiment || checkExperimentAudience(toClassName(config.audience));
+        console.log('run', config.run, config.audience);
+
+        window.hlx = window.hlx || {};
+        window.hlx.experiment = config;
+        if (config.run) {
+          const forced = forcedVariant || getLastExperimentVariant(config.id);
+          if (forced && config.variantNames.includes(forced)) {
+            config.selectedVariant = forced;
+          } else {
+            let random = Math.random();
+            let i = config.variantNames.length;
+            while (random > 0 && i > 0) {
+              i -= 1;
+              console.log(random, i);
+              random -= +config.variants[config.variantNames[i]].percentageSplit;
+            }
+            config.selectedVariant = config.variantNames[i];
+          }
+          setLastExperimentVariant(config.id, config.selectedVariant);
+          sampleRUM('experiment', { source: config.id, target: config.selectedVariant });
+          console.log(`running experiment (${window.hlx.experiment.id}) -> ${window.hlx.experiment.selectedVariant}`);
+          if (config.selectedVariant !== 'control') {
+            const currentPath = window.location.pathname;
+            const pageIndex = config.variants.control.pages.indexOf(currentPath);
+            if (pageIndex >= 0) {
+              const page = config.variants[config.selectedVariant].pages[pageIndex];
+              if (page) {
+                const experimentPath = new URL(page, window.location.href).pathname.split('.')[0];
+                if (experimentPath && experimentPath !== currentPath) {
+                  await replaceInner(experimentPath, document.querySelector('main'));
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  } catch (e) {
+    console.log('error testing', e);
+  }
+}
+
+
 /**
  * Gets placeholders object
  * @param {string} prefix
@@ -603,6 +817,13 @@ async function loadPage(doc) {
   await loadLazy(doc);
   // eslint-disable-next-line no-use-before-define
   loadDelayed(doc);
+
+  if (
+      window.location.hostname.endsWith('hlx.page') ||
+      window.location.hostname === 'localhost'
+  ) {
+      import('../../tools/preview/preview.js');
+  }
 }
 
 export function initHlx() {
@@ -717,6 +938,9 @@ export function decorateMain(main) {
  */
 async function loadEager(doc) {
   decorateTemplateAndTheme();
+
+  if (!window.hlx.lighthouse) await decorateTesting();
+
   const main = doc.querySelector('main');
   if (main) {
     decorateMain(main);

--- a/tools/preview/preview.css
+++ b/tools/preview/preview.css
@@ -1,0 +1,134 @@
+.hlx-preview-overlay {
+    z-index: 99;
+    position: fixed;
+    bottom: 32px;
+    right: 32px;
+    color: #eee;
+    font-weight: 600;
+    font-size: 24px;
+}
+
+.hlx-badge {
+    border-radius: 32px; 
+    background-color: #888;
+    color: #eee;
+    padding: 16px 32px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    position: relative;
+}
+
+.hlx-badge .hlx-open {
+    box-sizing: border-box;
+    position: relative;
+    display: block;
+    width: 22px;
+    height: 22px;
+    border: 2px solid;
+    border-radius: 100px;
+    margin-left: 16px;
+}
+.hlx-badge .hlx-open::after {
+    content: "";
+    display: block;
+    box-sizing: border-box;
+    position: absolute;
+    width: 6px;
+    height: 6px;
+    border-top: 2px solid;
+    border-right: 2px solid;
+    transform: rotate(-45deg);
+    left: 6px;
+    bottom: 5px;
+}
+
+.hlx-badge.hlx-testing {
+    background-color: #fa0f00;
+    color: #fff;
+}
+
+.hlx-popup {
+    position: absolute;
+    bottom: 64px;
+    right: 0;
+    background-color: #444;
+    min-width: 300px;
+    border-radius: 16px;
+    box-shadow: 0 0 10px #000;
+    font-size: 12px;
+}
+
+.hlx-popup a:any-link {
+    color: #eee;
+    border: 2px solid;
+    padding: 5px 12px;
+    display: inline-block;
+    border-radius: 20px;
+    text-decoration: none;
+}
+
+.hlx-popup .hlx-popup-header {
+    display: flex;
+    justify-content: space-between;
+    padding: 0 16px;
+    background-color: #222;
+    border-radius: 16px 16px 0 0;
+    padding: 24px 16px;
+}
+
+.hlx-popup h4, .hlx-popup h5 {
+    margin: 0;
+}
+
+.hlx-popup h4 {
+    font-size: 16px;
+}
+
+.hlx-popup h5 {
+    font-size: 14px;
+}
+
+
+.hlx-popup p {
+    margin: 0;
+}
+
+.hlx-popup::before {
+    content: '';
+    width: 0;
+    height: 0;
+    position: absolute;
+    border-left: 15px solid transparent;
+    border-right: 15px solid transparent;    
+    border-top: 15px solid #444;
+    bottom: -15px;
+    right: 30px;
+  }
+
+.hlx-hidden {
+    display: none;
+}
+
+.hlx-badge.hlx-experiment-status-active {
+    background-color: #280;
+}
+
+.hlx-variant {
+    margin: 16px;
+    display: flex;
+    padding: 16px;
+    border-radius: 16px;
+}
+
+.hlx-variant-selected {
+    background-color: #666;
+}
+
+.hlx-variant > div {
+    flex: 1 1 auto;
+}
+
+.hlx-variant > div.hlx-button {
+    flex: 0 0 auto;
+}

--- a/tools/preview/preview.js
+++ b/tools/preview/preview.js
@@ -12,11 +12,11 @@
 /* eslint-disable no-console */
 
 import {
-    loadCSS,
-    toClassName,
-    getMetadata,
-    getExperimentConfig,
-    checkTesting
+  loadCSS,
+  toClassName,
+  getMetadata,
+  getExperimentConfig,
+  checkTesting,
 } from '../../scripts/scripts.js';
 
 /**
@@ -24,14 +24,13 @@ import {
  * @return {Object} returns a badge or empty string
  */
 function createTesting() {
-    if (checkTesting()) {
-        const div = document.createElement('div');
-        div.className = 'hlx-testing hlx-badge';
-        div.innerHTML =
-            '<span title="This Page is part of an A/B Test run in Adobe Target">Testing On</span>';
-        return div;
-    }
-    return '';
+  if (checkTesting()) {
+    const div = document.createElement('div');
+    div.className = 'hlx-testing hlx-badge';
+    div.innerHTML = '<span title="This Page is part of an A/B Test run in Adobe Target">Testing On</span>';
+    return div;
+  }
+  return '';
 }
 
 /**
@@ -39,127 +38,122 @@ function createTesting() {
  * @return {Object} returns a badge or empty string
  */
 async function createExperiment() {
-    const selectedVariant =
-        window.hlx &&
-        window.hlx.experiment &&
-        window.hlx.experiment.selectedVariant
-            ? window.hlx.experiment.selectedVariant
-            : 'control';
-    const experiment = toClassName(getMetadata('experiment'));
-    console.log('preview experiment', experiment);
-    if (experiment) {
-        const config = await getExperimentConfig(experiment);
-        const createVariant = (variantName) => {
-            const variant = config.variants[variantName];
-            const split =
-                +variant.percentageSplit ||
-                1 -
-                    config.variantNames.reduce(
-                        (c, vn) => c + +config.variants[vn].percentageSplit,
-                        0
-                    );
-            const percentage = Math.round(split * 10000) / 100;
-            const div = document.createElement('div');
-
-            const experimentURL = new URL(window.location.href);
-            // this will retain other query params such as ?rum=on
-            experimentURL.searchParams.set(
-                'experiment',
-                `${experiment}/${variantName}`
-            );
-
-            div.className = `hlx-variant${
-                selectedVariant === variantName ? ' hlx-variant-selected' : ' '
-            }`;
-            div.innerHTML = `<div>
-      <h5>${variantName}</h5>
-        <p>${variant.label}</p>
-        <p>${percentage}%</p>
-        <p class="performance"></p>
-      </div>
-      <div class="hlx-button"><a href="${experimentURL.href}">Simulate</a></div>`;
-            return div;
-        };
-
-        const manifestButton = config.manifest
-            ? `<div class="hlx-button"><a href="${config.manifest}">Manifest</a></div>`
-            : '';
-
-        const div = document.createElement('div');
-        div.className = 'hlx-experiment hlx-badge';
-        div.classList.add(
-            `hlx-experiment-status-${toClassName(config.status)}`
+  const selectedVariant = window.hlx
+    && window.hlx.experiment
+    && window.hlx.experiment.selectedVariant
+    ? window.hlx.experiment.selectedVariant
+    : 'control';
+  const experiment = toClassName(getMetadata('experiment'));
+  console.log('preview experiment', experiment);
+  if (experiment) {
+    const config = await getExperimentConfig(experiment);
+    const createVariant = (variantName) => {
+      const variant = config.variants[variantName];
+      const split = +variant.percentageSplit || 1
+        - config.variantNames.reduce(
+          (c, vn) => c + +config.variants[vn].percentageSplit,
+          0,
         );
-        div.innerHTML = `Experiment: ${config.id} <span class="hlx-open"></span>
-      <div class="hlx-popup hlx-hidden">
-      <div class="hlx-popup-header">
-        <div>
-          <h4>${config.experimentName}</h4>
-          <div class="hlx-details">${config.status}, ${
-            config.audience
-        }, Blocks: ${config.variants.control.blocks.join(',')}</div>
-        </div>
-        <div>
-        ${manifestButton}
-        </div>
+      const percentage = Math.round(split * 10000) / 100;
+      const div = document.createElement('div');
+
+      const experimentURL = new URL(window.location.href);
+      // this will retain other query params such as ?rum=on
+      experimentURL.searchParams.set(
+        'experiment',
+        `${experiment}/${variantName}`,
+      );
+
+      div.className = `hlx-variant${
+        selectedVariant === variantName ? ' hlx-variant-selected' : ' '
+      }`;
+      div.innerHTML = `<div>
+    <h5>${variantName}</h5>
+      <p>${variant.label}</p>
+      <p>${percentage}%</p>
+      <p class="performance"></p>
+    </div>
+    <div class="hlx-button"><a href="${experimentURL.href}">Simulate</a></div>`;
+      return div;
+    };
+
+    const manifestButton = config.manifest
+      ? `<div class="hlx-button"><a href="${config.manifest}">Manifest</a></div>`
+      : '';
+
+    const div = document.createElement('div');
+    div.className = 'hlx-experiment hlx-badge';
+    div.classList.add(
+      `hlx-experiment-status-${toClassName(config.status)}`
+    );
+    div.innerHTML = `Experiment: ${config.id} <span class="hlx-open"></span>
+    <div class="hlx-popup hlx-hidden">
+    <div class="hlx-popup-header">
+      <div>
+        <h4>${config.experimentName}</h4>
+        <div class="hlx-details">${config.status}, ${
+          config.audience
+      }, Blocks: ${config.variants.control.blocks.join(',')}</div>
       </div>
-      <div class="hlx-variants"></div>
-      </div>`;
-        console.log(config.id);
-        const popup = div.querySelector('.hlx-popup');
+      <div>
+      ${manifestButton}
+      </div>
+    </div>
+    <div class="hlx-variants"></div>
+    </div>`;
+    console.log(config.id);
+    const popup = div.querySelector('.hlx-popup');
 
-        const variantMap = {};
+    const variantMap = {};
+    div.addEventListener('click', () => {
+      popup.classList.toggle('hlx-hidden');
 
-        div.addEventListener('click', () => {
-            popup.classList.toggle('hlx-hidden');
-
-            // the query is a bit slow, so I'm only fetching the results when the popup is opened
-            const resultsURL = new URL(
-                'https://helix-pages.anywhere.run/helix-services/run-query@v2/rum-experiments'
-            );
-            resultsURL.searchParams.set('experiment', experiment);
-            if (window.hlx.sidekickConfig && window.hlx.sidekickConfig.host) {
-                // restrict results to the production host, this also reduces query cost
-                resultsURL.searchParams.set(
-                    'domain',
-                    window.hlx.sidekickConfig.host
-                );
-            }
-            fetch(resultsURL.href).then(async (response) => {
-                const { results } = await response.json();
-                results.forEach((result) => {
-                    const nf = {
-                        format: (num) => `${Math.floor(num)}%`
-                    };
-                    const variant = variantMap[result.variant];
-                    if (variant) {
-                        const performance =
-                            variant.querySelector('.performance');
-                        performance.innerHTML = `
-              <span>click rate: ${nf.format(
-                  100 * Number.parseFloat(result.variant_conversion_rate)
-              )}</span>
-              <span>vs. ${nf.format(
-                  100 * Number.parseFloat(result.control_conversion_rate)
-              )}</span>
-              <span>significance: ${nf.format(
-                  100 * Number.parseFloat(result.p_value)
-              )}</span> <!-- everything below 95% is not good enough for the social sciences to be considered significant --->
-            `;
-                    }
-                });
-            });
+      // the query is a bit slow, so I'm only fetching the results when the popup is opened
+      const resultsURL = new URL(
+        'https://helix-pages.anywhere.run/helix-services/run-query@v2/rum-experiments',
+      );
+      resultsURL.searchParams.set('experiment', experiment);
+      if (window.hlx.sidekickConfig && window.hlx.sidekickConfig.host) {
+        // restrict results to the production host, this also reduces query cost
+        resultsURL.searchParams.set(
+            'domain',
+            window.hlx.sidekickConfig.host,
+        );
+      }
+      fetch(resultsURL.href).then(async (response) => {
+        const { results } = await response.json();
+        results.forEach((result) => {
+          const nf = {
+              format: (num) => `${Math.floor(num)}%`,
+          };
+          const variant = variantMap[result.variant];
+          if (variant) {
+              const performance = variant.querySelector('.performance');
+              performance.innerHTML = `
+        <span>click rate: ${nf.format(
+            100 * Number.parseFloat(result.variant_conversion_rate),
+        )}</span>
+        <span>vs. ${nf.format(
+            100 * Number.parseFloat(result.control_conversion_rate),
+        )}</span>
+        <span>significance: ${nf.format(
+            100 * Number.parseFloat(result.p_value),
+        )}</span> <!-- everything below 95% is not good enough for the social sciences to be considered significant --->
+      `;
+        }
         });
+      });
+    });
 
-        const variants = div.querySelector('.hlx-variants');
-        config.variantNames.forEach((vname) => {
-            const variantDiv = createVariant(vname);
-            variants.append(variantDiv);
-            variantMap[vname] = variantDiv;
-        });
-        return div;
-    }
-    return '';
+    const variants = div.querySelector('.hlx-variants');
+    config.variantNames.forEach((vname) => {
+      const variantDiv = createVariant(vname);
+      variants.append(variantDiv);
+      variantMap[vname] = variantDiv;
+    });
+    return div;
+  }
+  return '';
 }
 
 /**
@@ -167,16 +161,16 @@ async function createExperiment() {
  * @return {Object} returns a badge or empty string
  */
 async function decoratePreviewMode() {
-    loadCSS('/tools/preview/preview.css');
-    const overlay = document.createElement('div');
-    overlay.className = 'hlx-preview-overlay';
-    overlay.append(createTesting());
-    overlay.append(await createExperiment());
-    document.body.append(overlay);
+  loadCSS('/tools/preview/preview.css');
+  const overlay = document.createElement('div');
+  overlay.className = 'hlx-preview-overlay';
+  overlay.append(createTesting());
+  overlay.append(await createExperiment());
+  document.body.append(overlay);
 }
 
 try {
-    decoratePreviewMode();
+  decoratePreviewMode();
 } catch (e) {
-    console.log(e);
+  console.log(e);
 }

--- a/tools/preview/preview.js
+++ b/tools/preview/preview.js
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-disable no-console */
+
+import {
+    loadCSS,
+    toClassName,
+    getMetadata,
+    getExperimentConfig,
+    checkTesting
+} from '../../scripts/scripts.js';
+
+/**
+ * Create Badge if a Page is enlisted in an Adobe Target test
+ * @return {Object} returns a badge or empty string
+ */
+function createTesting() {
+    if (checkTesting()) {
+        const div = document.createElement('div');
+        div.className = 'hlx-testing hlx-badge';
+        div.innerHTML =
+            '<span title="This Page is part of an A/B Test run in Adobe Target">Testing On</span>';
+        return div;
+    }
+    return '';
+}
+
+/**
+ * Create Badge if a Page is enlisted in a Helix Experiment
+ * @return {Object} returns a badge or empty string
+ */
+async function createExperiment() {
+    const selectedVariant =
+        window.hlx &&
+        window.hlx.experiment &&
+        window.hlx.experiment.selectedVariant
+            ? window.hlx.experiment.selectedVariant
+            : 'control';
+    const experiment = toClassName(getMetadata('experiment'));
+    console.log('preview experiment', experiment);
+    if (experiment) {
+        const config = await getExperimentConfig(experiment);
+        const createVariant = (variantName) => {
+            const variant = config.variants[variantName];
+            const split =
+                +variant.percentageSplit ||
+                1 -
+                    config.variantNames.reduce(
+                        (c, vn) => c + +config.variants[vn].percentageSplit,
+                        0
+                    );
+            const percentage = Math.round(split * 10000) / 100;
+            const div = document.createElement('div');
+
+            const experimentURL = new URL(window.location.href);
+            // this will retain other query params such as ?rum=on
+            experimentURL.searchParams.set(
+                'experiment',
+                `${experiment}/${variantName}`
+            );
+
+            div.className = `hlx-variant${
+                selectedVariant === variantName ? ' hlx-variant-selected' : ' '
+            }`;
+            div.innerHTML = `<div>
+      <h5>${variantName}</h5>
+        <p>${variant.label}</p>
+        <p>${percentage}%</p>
+        <p class="performance"></p>
+      </div>
+      <div class="hlx-button"><a href="${experimentURL.href}">Simulate</a></div>`;
+            return div;
+        };
+
+        const manifestButton = config.manifest
+            ? `<div class="hlx-button"><a href="${config.manifest}">Manifest</a></div>`
+            : '';
+
+        const div = document.createElement('div');
+        div.className = 'hlx-experiment hlx-badge';
+        div.classList.add(
+            `hlx-experiment-status-${toClassName(config.status)}`
+        );
+        div.innerHTML = `Experiment: ${config.id} <span class="hlx-open"></span>
+      <div class="hlx-popup hlx-hidden">
+      <div class="hlx-popup-header">
+        <div>
+          <h4>${config.experimentName}</h4>
+          <div class="hlx-details">${config.status}, ${
+            config.audience
+        }, Blocks: ${config.variants.control.blocks.join(',')}</div>
+        </div>
+        <div>
+        ${manifestButton}
+        </div>
+      </div>
+      <div class="hlx-variants"></div>
+      </div>`;
+        console.log(config.id);
+        const popup = div.querySelector('.hlx-popup');
+
+        const variantMap = {};
+
+        div.addEventListener('click', () => {
+            popup.classList.toggle('hlx-hidden');
+
+            // the query is a bit slow, so I'm only fetching the results when the popup is opened
+            const resultsURL = new URL(
+                'https://helix-pages.anywhere.run/helix-services/run-query@v2/rum-experiments'
+            );
+            resultsURL.searchParams.set('experiment', experiment);
+            if (window.hlx.sidekickConfig && window.hlx.sidekickConfig.host) {
+                // restrict results to the production host, this also reduces query cost
+                resultsURL.searchParams.set(
+                    'domain',
+                    window.hlx.sidekickConfig.host
+                );
+            }
+            fetch(resultsURL.href).then(async (response) => {
+                const { results } = await response.json();
+                results.forEach((result) => {
+                    const nf = {
+                        format: (num) => `${Math.floor(num)}%`
+                    };
+                    const variant = variantMap[result.variant];
+                    if (variant) {
+                        const performance =
+                            variant.querySelector('.performance');
+                        performance.innerHTML = `
+              <span>click rate: ${nf.format(
+                  100 * Number.parseFloat(result.variant_conversion_rate)
+              )}</span>
+              <span>vs. ${nf.format(
+                  100 * Number.parseFloat(result.control_conversion_rate)
+              )}</span>
+              <span>significance: ${nf.format(
+                  100 * Number.parseFloat(result.p_value)
+              )}</span> <!-- everything below 95% is not good enough for the social sciences to be considered significant --->
+            `;
+                    }
+                });
+            });
+        });
+
+        const variants = div.querySelector('.hlx-variants');
+        config.variantNames.forEach((vname) => {
+            const variantDiv = createVariant(vname);
+            variants.append(variantDiv);
+            variantMap[vname] = variantDiv;
+        });
+        return div;
+    }
+    return '';
+}
+
+/**
+ * Decorates Preview mode badges and overlays
+ * @return {Object} returns a badge or empty string
+ */
+async function decoratePreviewMode() {
+    loadCSS('/tools/preview/preview.css');
+    const overlay = document.createElement('div');
+    overlay.className = 'hlx-preview-overlay';
+    overlay.append(createTesting());
+    overlay.append(await createExperiment());
+    document.body.append(overlay);
+}
+
+try {
+    decoratePreviewMode();
+} catch (e) {
+    console.log(e);
+}


### PR DESCRIPTION
Add JS to support basic instant experimentation use-case

Test URLs:
- Before: https://main--vodafone--hlxsites.hlx.page/
- After: https://experimentation--vodafone--hlxsites.hlx.page/
